### PR TITLE
Install gawk in photon base image

### DIFF
--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -6,7 +6,7 @@ COPY rootfs /
 
 RUN tdnf remove toybox -y && \
     tdnf upgrade -y && \
-    install_packages tar gzip sudo procps-ng libaio-devel which shadow sed findutils
+    install_packages tar gzip sudo procps-ng libaio-devel which shadow sed findutils awk
 
 RUN useradd -ms /bin/bash bitnami && groupadd bitnami && usermod -g bitnami bitnami && \
     mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -6,7 +6,7 @@ COPY rootfs /
 
 RUN tdnf remove toybox -y && \
     tdnf upgrade -y && \
-    install_packages tar gzip sudo procps-ng libaio-devel which shadow sed findutils awk
+    install_packages tar gzip sudo procps-ng libaio-devel which shadow sed findutils gawk
 
 RUN useradd -ms /bin/bash bitnami && groupadd bitnami && usermod -g bitnami bitnami && \
     mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \


### PR DESCRIPTION
```shell
$ docker build . -t carrodher/photon-gawk --no-cache
Sending build context to Docker daemon   12.8kB
Step 1/9 : FROM photon:3.0
 ---> 3afe4f080255
...
Step 5/9 : RUN tdnf remove toybox -y &&     tdnf upgrade -y &&     install_packages tar gzip sudo procps-ng libaio-devel which shadow sed findutils gawk
 ---> Running in 9e865df463e1
...
Installing:
libaio                   x86_64       0.3.110-3.ph3    photon-updates  52.69k 53950
mpfr                     x86_64       4.0.1-2.ph3      photon-updates 507.21k 519384
cracklib                 x86_64       2.9.6-8.ph3      photon        43.37k 44408
shadow-tools             x86_64       4.6-4.ph3        photon-updates 157.35k 161128
ncurses                  x86_64       6.1-1.ph3        photon       348.25k 356613
Linux-PAM                x86_64       1.3.0-1.ph3      photon         1.06M 1113660
gawk                     x86_64       4.2.1-1.ph3      photon         2.20M 2304491
findutils                x86_64       4.6.0-5.ph3      photon       518.63k 531082
sed                      x86_64       4.5-1.ph3        photon       113.46k 116183
shadow                   x86_64       4.6-4.ph3        photon-updates   1.76M 1843817
which                    x86_64       2.21-5.ph3       photon        32.11k 32883
libaio-devel             x86_64       0.3.110-3.ph3    photon-updates  22.88k 23434
procps-ng                x86_64       3.3.15-1.ph3     photon         1.35M 1419515
sudo                     x86_64       1.8.23-2.ph3     photon-updates   3.03M 3177315
gzip                     x86_64       1.9-2.ph3        photon-updates 144.63k 148098
tar                      x86_64       1.30-3.ph3       photon-updates   4.65M 4880464

Total installed size:  15.95M 16726425

Testing transaction
Running transaction
Installing/Updating: cracklib-2.9.6-8.ph3.x86_64
using empty dict to provide pw_dict
Installing/Updating: Linux-PAM-1.3.0-1.ph3.x86_64
Installing/Updating: shadow-tools-4.6-4.ph3.x86_64
Installing/Updating: shadow-4.6-4.ph3.x86_64
Installing/Updating: ncurses-6.1-1.ph3.x86_64
Installing/Updating: mpfr-4.0.1-2.ph3.x86_64
Installing/Updating: libaio-0.3.110-3.ph3.x86_64
Installing/Updating: libaio-devel-0.3.110-3.ph3.x86_64
Installing/Updating: gawk-4.2.1-1.ph3.x86_64
Installing/Updating: procps-ng-3.3.15-1.ph3.x86_64
Installing/Updating: sudo-1.8.23-2.ph3.x86_64
Installing/Updating: tar-1.30-3.ph3.x86_64
Installing/Updating: gzip-1.9-2.ph3.x86_64
Installing/Updating: which-2.21-5.ph3.x86_64
Installing/Updating: sed-4.5-1.ph3.x86_64
Installing/Updating: findutils-4.6.0-5.ph3.x86_64

Complete!
Removing intermediate container 9e865df463e1
...
Step 9/9 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Running in 83a6371a846f
Removing intermediate container 83a6371a846f
 ---> 30ad7824c0fc
Successfully built 30ad7824c0fc
Successfully tagged carrodher/photon-gawk:latest
```
```bash
$ docker run carrodher/photon-gawk gawk --version
GNU Awk 4.2.1, API: 2.0 (GNU MPFR 4.0.1, GNU MP 6.1.2)
Copyright (C) 1989, 1991-2018 Free Software Foundation.

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 3 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program. If not, see http://www.gnu.org/licenses/.
```